### PR TITLE
Create a New Dataframe for Map

### DIFF
--- a/lotus/sem_ops/sem_map.py
+++ b/lotus/sem_ops/sem_map.py
@@ -126,7 +126,7 @@ class SemMapDataframe:
             strategy=strategy,
         )
 
-        new_df = self._obj
+        new_df = self._obj.copy()
         new_df[suffix] = outputs
         if return_explanations:
             new_df["explanation" + suffix] = explanations


### PR DESCRIPTION
Previously, map would update the dataframe in place. Changing it so that map creates a new dataframe. This fits better with the semantics of the other operators.